### PR TITLE
Correct modify-syntax-entry entry to restore //-style comments

### DIFF
--- a/ess-stata-mode.el
+++ b/ess-stata-mode.el
@@ -48,7 +48,7 @@
     ;; asterisk at bol comments taken care of by
     ;; `syntax-propertize-function'.
     (modify-syntax-entry ?*  ". 23b"   tbl)
-    (modify-syntax-entry ?\n ">"  tbl)
+    (modify-syntax-entry ?\n "> b"  tbl)
     (modify-syntax-entry ?+ "." tbl)
     (modify-syntax-entry ?- "." tbl)
     (modify-syntax-entry ?= "." tbl)


### PR DESCRIPTION
Comments beginning with "//" were no longer recognised for font-locking. This change restores previous behaviour.