### PR TITLE
goto-char misplaced in stata defun

### DIFF
--- a/ess-stata-mode.el
+++ b/ess-stata-mode.el
@@ -158,7 +158,7 @@ This function is placed in `ess-presend-filter-functions'."
       (ess-wait-for-process inf-proc t))
     (ess-send-string inf-proc "set more off")
     (with-current-buffer inf-buf
-    (goto-char (point-max))
+      (goto-char (point-max))
       (add-hook 'ess-presend-filter-functions 'ess-sta-remove-comments nil 'local)
       (run-mode-hooks 'ess-stata-post-run-hook))
     inf-buf))

--- a/ess-stata-mode.el
+++ b/ess-stata-mode.el
@@ -157,8 +157,8 @@ This function is placed in `ess-presend-filter-functions'."
       (ess-send-string inf-proc "q")
       (ess-wait-for-process inf-proc t))
     (ess-send-string inf-proc "set more off")
-    (goto-char (point-max))
     (with-current-buffer inf-buf
+    (goto-char (point-max))
       (add-hook 'ess-presend-filter-functions 'ess-sta-remove-comments nil 'local)
       (run-mode-hooks 'ess-stata-post-run-hook))
     inf-buf))


### PR DESCRIPTION
`(goto-char (point-max))` should take effect in inf-buf, but is presently on the wrong side of the `(with-current-buffer inf-buf`line.