### PR TITLE
Change inferior-ess-prompt to deal with for loops

### DIFF
--- a/ess-stata-mode.el
+++ b/ess-stata-mode.el
@@ -78,7 +78,7 @@
     ;; --more-- is necessary here (hangs otherwise if startup stata.msg is big)
     (inferior-ess-primary-prompt   . "[.:] \\|--more--")
     (inferior-ess-secondary-prompt . ">\\|--more--")
-    (inferior-ess-prompt           . "\\([.:>] \\|--more--\\)")
+    (inferior-ess-prompt           . "\\( *[0-9]*[.:>] \\|--more--\\)")
     (comint-use-prompt-regexp      . t)
     (inferior-ess-search-list-command   . "set more off\n search()\n")
     (ess-execute-screen-options-command . "set linesize %s\n")


### PR DESCRIPTION
Inside a for-loop the Stata prompt changes like this:
```stata
. forvalues x = 1/5  {
  2. di `x'
  3. }
}
```
A small change to inferior-ess-prompt accommodates this